### PR TITLE
Add simple student data API and page

### DIFF
--- a/data/students.json
+++ b/data/students.json
@@ -1,0 +1,12 @@
+[
+  {"id": 1, "name": "Alice Johnson", "age": 20, "grade": "A"},
+  {"id": 2, "name": "Bob Smith", "age": 19, "grade": "B"},
+  {"id": 3, "name": "Charlie Brown", "age": 21, "grade": "C"},
+  {"id": 4, "name": "Dana White", "age": 22, "grade": "B"},
+  {"id": 5, "name": "Evan Davis", "age": 20, "grade": "A"},
+  {"id": 6, "name": "Fiona Green", "age": 23, "grade": "A"},
+  {"id": 7, "name": "George Hill", "age": 19, "grade": "C"},
+  {"id": 8, "name": "Hannah Lee", "age": 21, "grade": "B"},
+  {"id": 9, "name": "Ian Miller", "age": 22, "grade": "B"},
+  {"id": 10, "name": "Julia Nolan", "age": 20, "grade": "A"}
+]

--- a/pages/api/students.ts
+++ b/pages/api/students.ts
@@ -1,0 +1,9 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import students from '../../data/students.json';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.status(200).json(students);
+}

--- a/pages/students.tsx
+++ b/pages/students.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+interface Student {
+  id: number;
+  name: string;
+  age: number;
+  grade: string;
+}
+
+export default function StudentsPage() {
+  const [students, setStudents] = useState<Student[]>([]);
+
+  useEffect(() => {
+    fetch('/api/students')
+      .then((res) => res.json())
+      .then((data) => setStudents(data));
+  }, []);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Student Database</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Age</th>
+            <th>Grade</th>
+          </tr>
+        </thead>
+        <tbody>
+          {students.map((student) => (
+            <tr key={student.id}>
+              <td>{student.id}</td>
+              <td>{student.name}</td>
+              <td>{student.age}</td>
+              <td>{student.grade}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add sample student dataset
- expose API route `/api/students`
- create `/students` page to show the data

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b4b35e88321b464bcd7953c59a7