### PR TITLE
Add simple student database with dynamic pages

### DIFF
--- a/data/students.json
+++ b/data/students.json
@@ -1,0 +1,5 @@
+[
+  {"id": "1", "name": "Alice", "age": 20, "major": "Mathematics"},
+  {"id": "2", "name": "Bob", "age": 22, "major": "Physics"},
+  {"id": "3", "name": "Charlie", "age": 21, "major": "Chemistry"}
+]

--- a/lib/students.ts
+++ b/lib/students.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+
+import { Student } from '@/types/student';
+
+const dataFile = path.join(process.cwd(), 'data', 'students.json');
+
+export function getStudents(): Student[] {
+  const data = fs.readFileSync(dataFile, 'utf8');
+  return JSON.parse(data) as Student[];
+}
+
+export function getStudentById(id: string): Student | undefined {
+  const students = getStudents();
+  return students.find(s => s.id === id);
+}

--- a/pages/students/[id].tsx
+++ b/pages/students/[id].tsx
@@ -1,0 +1,46 @@
+import { GetStaticPaths, GetStaticProps } from 'next';
+import Link from 'next/link';
+
+import { getStudentById, getStudents } from '@/lib/students';
+import { Student } from '@/types/student';
+
+interface StudentPageProps {
+  student: Student;
+}
+
+export default function StudentPage({ student }: StudentPageProps) {
+  return (
+    <div>
+      <h1>{student.name}</h1>
+      <p>Age: {student.age}</p>
+      <p>Major: {student.major}</p>
+      <p>
+        <Link href="/students">Back to list</Link>
+      </p>
+    </div>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const students = getStudents();
+  const paths = students.map(student => ({ params: { id: student.id } }));
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<StudentPageProps> = async ({ params }) => {
+  const id = params?.id as string;
+  const student = getStudentById(id);
+
+  if (!student) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      student,
+    },
+  };
+};

--- a/pages/students/index.tsx
+++ b/pages/students/index.tsx
@@ -1,0 +1,33 @@
+import { GetStaticProps } from 'next';
+import Link from 'next/link';
+
+import { getStudents } from '@/lib/students';
+import { Student } from '@/types/student';
+
+interface StudentsPageProps {
+  students: Student[];
+}
+
+export default function StudentsPage({ students }: StudentsPageProps) {
+  return (
+    <div>
+      <h1>Students</h1>
+      <ul>
+        {students.map(student => (
+          <li key={student.id}>
+            <Link href={`/students/${student.id}`}>{student.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps<StudentsPageProps> = async () => {
+  const students = getStudents();
+  return {
+    props: {
+      students,
+    },
+  };
+};

--- a/types/student.ts
+++ b/types/student.ts
@@ -1,0 +1,6 @@
+export interface Student {
+  id: string;
+  name: string;
+  age: number;
+  major: string;
+}


### PR DESCRIPTION
## Summary
- add `Student` type and utilities to load JSON-backed student data
- create student listing page and dynamic pages for each student

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: Failed to fetch Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_6894ecf98ad48322b183391ee5639666